### PR TITLE
Past entries display

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -67,11 +67,11 @@ class App extends Component {
     const cleanedData = {
       primaryEmotion: respData.emotion_prediction,
       emotionRatings: {
-        anger: respData.emotion_scores.Anger,
-        fear: respData.emotion_scores.Fear,
-        joy: respData.emotion_scores.Joy,
-        neutral: respData.emotion_scores.Neutral,
-        sadness: respData.emotion_scores.Sadness,
+        anger: `${(respData.emotion_scores.Anger * 100).toFixed(1)}%`,
+        fear: `${(respData.emotion_scores.Fear * 100).toFixed(1)}%`,
+        joy: `${(respData.emotion_scores.Joy * 100).toFixed(1)}%`,
+        neutral: `${(respData.emotion_scores.Neutral * 100).toFixed(1)}%`,
+        sadness: `${(respData.emotion_scores.Sadness * 100).toFixed(1)}%`,
       },
       perceivedAs: respData.sentiment_prediction,
       perceptionRatings: {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -50,6 +50,21 @@ class App extends Component {
     name === 'open-nav' ? this.setState({ navWidth: '15%' }) : this.setState({ navWidth: '0%' })
   }
 
+  toggleFlag = (id, flagged) => {
+    console.log(id)
+    console.log(flagged)
+    const changeTo = !flagged ? 'true' : false
+    const entriesCopy = this.state.allEntries.map((entry) => {
+      if (id === entry.id) {
+        entry.flagged = changeTo
+        console.log('id matches')
+      }
+      return entry
+    })
+    console.log(entriesCopy)
+    this.setState({ allEntries: entriesCopy })
+  }
+
   cleanResponseData = async (respData) => {
     const cleanedData = {
       primaryEmotion: respData.emotion_prediction,
@@ -101,7 +116,7 @@ class App extends Component {
         <Route
           exact
           path='/past_entries/:name'
-          render={({ match }) => <PastEntryView viewType={match.params.name} entries={this.state.allEntries} toggleEntry={this.toggleCurrentEntry} />} />
+          render={({ match }) => <PastEntryView viewType={match.params.name} entries={this.state.allEntries} toggleEntry={this.toggleCurrentEntry} toggleFlag={this.toggleFlag} />} />
         </Switch>
       </div>
     )

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -51,17 +51,15 @@ class App extends Component {
   }
 
   toggleFlag = (id, flagged) => {
-    console.log(id)
-    console.log(flagged)
     const changeTo = !flagged ? 'true' : false
     const entriesCopy = this.state.allEntries.map((entry) => {
       if (id === entry.id) {
         entry.flagged = changeTo
-        console.log('id matches')
       }
+
       return entry
     })
-    console.log(entriesCopy)
+
     this.setState({ allEntries: entriesCopy })
   }
 

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -3,12 +3,14 @@ import { useHistory } from 'react-router-dom'
 import '../styles/Card.css'
 
 
-const Card = ({ title, id, addEntry }) => {
+const Card = ({ title, emotion, perception, id, addEntry }) => {
   let history = useHistory()
 
   return(
     <section className='entry-card' key={id} onClick={() => addEntry(id) && history.push(`/${id}`)} >
       <p>{title}</p>
+      <p>{emotion}</p>
+      <p>{perception}</p>
     </section>
   )
 }

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -3,14 +3,20 @@ import { useHistory } from 'react-router-dom'
 import '../styles/Card.css'
 
 
-const Card = ({ title, emotion, perception, id, addEntry }) => {
+const Card = ({ title, emotion, perception, addEntry, flagToggle, id, flagged }) => {
   let history = useHistory()
+  const flagStatus = !flagged ? 'Flag Entry' : 'Remove Flag'
 
   return(
-    <section className='entry-card' key={id} onClick={() => addEntry(id) && history.push(`/${id}`)} >
-      <h3>{title}</h3>
-      <p>Primary Emotion: {emotion}</p>
-      <p>Perceived As: {perception}</p>
+    <section className='entry-card' key={id} >
+      <header className='card-header'>
+        <h3>{title}</h3>
+        <button type='button' className='flag-button' onClick={() => flagToggle(id, flagged)} >{flagStatus}</button>
+      </header>
+      <div className='card-details' onClick={() => addEntry(id) && history.push(`/${id}`)}>
+        <p>Primary Emotion: {emotion}</p>
+        <p>Perceived As: {perception}</p>
+      </div>
     </section>
   )
 }

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -8,9 +8,9 @@ const Card = ({ title, emotion, perception, id, addEntry }) => {
 
   return(
     <section className='entry-card' key={id} onClick={() => addEntry(id) && history.push(`/${id}`)} >
-      <p>{title}</p>
-      <p>{emotion}</p>
-      <p>{perception}</p>
+      <h3>{title}</h3>
+      <p>Primary Emotion: {emotion}</p>
+      <p>Perceived As: {perception}</p>
     </section>
   )
 }

--- a/src/components/Nav.js
+++ b/src/components/Nav.js
@@ -8,10 +8,10 @@ const Nav = ({ wid, closeNav }) => {
     <section className='navigation-container' style={{width: wid }} >
     <button name='close-nav' onClick={(event) => closeNav(event.target)}>Close</button>
       <NavLink to={`/past_entries/all`} >
-        <h3 className='all-entries-link' name='all'>All Entries</h3>
+        <h3 className='all-entries-link' name='all' onClick={(event) => closeNav(event.target)}>All Entries</h3>
       </NavLink>
       <NavLink to={`/past_entries/flagged`} >
-        <h3 className='flagged-entries-link' name='flagged'>Flagged Entries</h3>
+        <h3 className='flagged-entries-link' name='flagged' onClick={(event) => closeNav(event.target)}>Flagged Entries</h3>
       </NavLink>
     </section>
   )

--- a/src/components/PastEntryView.js
+++ b/src/components/PastEntryView.js
@@ -19,6 +19,7 @@ const PastEntryView = ({ viewType, entries, toggleEntry, toggleFlag }) => {
       }
       return false
     })
+    
     displayEntries = filteredDisplayEntries.map((entry) => {
       return <Card title={entry.title} emotion={entry.entryAnalysis.primaryEmotion} perception={entry.entryAnalysis.perceivedAs} flagged={entry.flagged} key={entry.id} id={entry.id} addEntry={toggleEntry} flagToggle={toggleFlag} />
     })

--- a/src/components/PastEntryView.js
+++ b/src/components/PastEntryView.js
@@ -4,12 +4,12 @@ import '../styles/PastEntryView.css'
 import Card from './Card'
 
 
-const PastEntryView = ({ viewType, entries, toggleEntry }) => {
+const PastEntryView = ({ viewType, entries, toggleEntry, toggleFlag }) => {
 
   let displayEntries = viewType === 'all' ? 
-  entries.map(entry => <Card title={entry.title} emotion={entry.entryAnalysis.primaryEmotion} perception={entry.entryAnalysis.perceivedAs} key={entry.id} id={entry.id} addEntry={toggleEntry} />) : 
+  entries.map(entry => <Card title={entry.title} emotion={entry.entryAnalysis.primaryEmotion} perception={entry.entryAnalysis.perceivedAs} flagged={entry.flagged} key={entry.id} id={entry.id} addEntry={toggleEntry} flagToggle={toggleFlag} />) : 
   entries.filter((entry) => {
-    return !entry.flagged ? false : <Card title={entry.title} emotion={entry.entryAnalysis.primaryEmotion} perception={entry.entryAnalysis.perceivedAs} key={entry.id} id={entry.id} />
+    return !entry.flagged ? false : <Card title={entry.title} emotion={entry.entryAnalysis.primaryEmotion} perception={entry.entryAnalysis.perceivedAs} flagged={entry.flagged} key={entry.id} id={entry.id} flagToggle={toggleFlag} />
   })
 
   const viewTitle = viewType === 'all' ? 'All Entries' : 'Flagged Entries'

--- a/src/components/PastEntryView.js
+++ b/src/components/PastEntryView.js
@@ -5,12 +5,24 @@ import Card from './Card'
 
 
 const PastEntryView = ({ viewType, entries, toggleEntry, toggleFlag }) => {
+  let displayEntries;
 
-  let displayEntries = viewType === 'all' ? 
-  entries.map(entry => <Card title={entry.title} emotion={entry.entryAnalysis.primaryEmotion} perception={entry.entryAnalysis.perceivedAs} flagged={entry.flagged} key={entry.id} id={entry.id} addEntry={toggleEntry} flagToggle={toggleFlag} />) : 
-  entries.filter((entry) => {
-    return !entry.flagged ? false : <Card title={entry.title} emotion={entry.entryAnalysis.primaryEmotion} perception={entry.entryAnalysis.perceivedAs} flagged={entry.flagged} key={entry.id} id={entry.id} flagToggle={toggleFlag} />
-  })
+  if (viewType === 'all') {
+    displayEntries = entries.map((entry) => {
+      return <Card title={entry.title} emotion={entry.entryAnalysis.primaryEmotion} perception={entry.entryAnalysis.perceivedAs} flagged={entry.flagged} key={entry.id} id={entry.id} addEntry={toggleEntry} flagToggle={toggleFlag} />
+    })
+
+  } else if (viewType !== 'all') {
+    let filteredDisplayEntries = entries.filter((entry) => {
+      if (entry.flagged) {
+        return <Card title={entry.title} emotion={entry.entryAnalysis.primaryEmotion} perception={entry.entryAnalysis.perceivedAs} flagged={entry.flagged} key={entry.id} id={entry.id} addEntry={toggleEntry} flagToggle={toggleFlag} />
+      }
+      return false
+    })
+    displayEntries = filteredDisplayEntries.map((entry) => {
+      return <Card title={entry.title} emotion={entry.entryAnalysis.primaryEmotion} perception={entry.entryAnalysis.perceivedAs} flagged={entry.flagged} key={entry.id} id={entry.id} addEntry={toggleEntry} flagToggle={toggleFlag} />
+    })
+  }
 
   const viewTitle = viewType === 'all' ? 'All Entries' : 'Flagged Entries'
 

--- a/src/components/PastEntryView.js
+++ b/src/components/PastEntryView.js
@@ -7,18 +7,22 @@ import Card from './Card'
 const PastEntryView = ({ viewType, entries, toggleEntry }) => {
 
   let displayEntries = viewType === 'all' ? 
-  entries.map(entry => <Card title={entry.title} key={entry.id} id={entry.id} addEntry={toggleEntry} />) : 
+  entries.map(entry => <Card title={entry.title} emotion={entry.entryAnalysis.primaryEmotion} perception={entry.entryAnalysis.perceivedAs} key={entry.id} id={entry.id} addEntry={toggleEntry} />) : 
   entries.filter((entry) => {
-    return !entry.flagged ? false : <Card title={entry.title} key={entry.id} id={entry.id} />
+    return !entry.flagged ? false : <Card title={entry.title} emotion={entry.entryAnalysis.primaryEmotion} perception={entry.entryAnalysis.perceivedAs} key={entry.id} id={entry.id} />
   })
+
+  const viewTitle = viewType === 'all' ? 'All Entries' : 'Flagged Entries'
 
   return(
     <section className='past-entries-view'>
       <Link to='/'>
         <h3 className='back-to-main-link'>--Back to Main Page</h3>
       </Link>
-      <p>This is where all user entry cards will go</p>
-      <div className='entries-container'>{displayEntries}</div>
+      <section className='entries-container'>
+        <h2>{viewTitle}</h2>
+        <div className='card-container'>{displayEntries}</div>
+      </section>
     </section>
   )
 }

--- a/src/styles/Card.css
+++ b/src/styles/Card.css
@@ -1,0 +1,7 @@
+.entry-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid gold;
+}

--- a/src/styles/Card.css
+++ b/src/styles/Card.css
@@ -5,3 +5,19 @@
   justify-content: center;
   border: 1px solid gold;
 }
+
+.card-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.flag-button {
+  height: 40%;
+}
+
+.card-details {
+  height: 100%;
+  width: 100%;
+}

--- a/src/styles/PastEntryView.css
+++ b/src/styles/PastEntryView.css
@@ -10,5 +10,5 @@
   grid-template-columns: repeat(3, 1fr);
   grid-gap: 1em;
   margin: 1.5em;
-  width: 100%;
+  width: 95%;
 }

--- a/src/styles/PastEntryView.css
+++ b/src/styles/PastEntryView.css
@@ -1,0 +1,14 @@
+.entries-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.card-container {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-gap: 1em;
+  margin: 1.5em;
+  width: 100%;
+}


### PR DESCRIPTION
## What (if any) new features are implemented in this pull request?

- This adds basic layout styling to the past entries
- Adds a button on the past entries cards to flag an entry to add it to a list
- Adds expression to the cleanup fcn to display feedback info as percentages
- Adds onClick fcn to navigation links so the navigation bar closes when a link is clicked on

## What (if any) refactoring did you do?

N/A

## Were there any issues that arose?

N/A

## What (if any) bugs did you fix?

- Had to add a map in addition to the filter fcn in the past entries view because React would not recognize it as an array.

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] run locally/ browser
- [x] dev tools
- [] terminal
- [] Cypress

## Checklist:

- [x] I have performed a self-review of my own code
- [x] No console error messages
- [] No console warning messages

## Other Important Information

## Issues Closed
closes #44 